### PR TITLE
mail forwarder for notifications

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM centos:7
 
 ENV CMK_VERSION="1.2.8p12"
 ENV CMK_SITE="mva"
+ENV MAILHUB="undefined"
 
 RUN \
     yum -y install epel-release && \
@@ -46,7 +47,9 @@ RUN \
         fping \
         libmcrypt \
         perl-Net-SNMP \
-        which
+        which \
+        ssmtp \
+        mailx
 
 ADD    bootstrap.sh /opt/
 EXPOSE 5000/tcp

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ Start Check_MK using:
            nlmacamp/check_mk
 ```
 
-Check the status of check_mk using:
+*OPTIONAL:* Specify outgoing mail server with `-e "MAILHUB=<IP:PORT>"`
 
+Check the status of check_mk using:
 
 ```bash
 docker exec -it check_mk omd status

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,18 @@
 #!/bin/bash
 
+# Create SSMTP config
+CFGFILE=/etc/ssmtp/ssmtp.conf
+
+cat >$CFGFILE <<CONFIG
+root=root
+mailhub=${MAILHUB}
+FromLineOverride=YES
+CONFIG
+
+chmod 640 $CFGFILE
+chown root:mail $CFGFILE
+
+
+# Start check_mk
 omd start && tail -f /var/log/nagios.log
 


### PR DESCRIPTION
You can now specify an outgoing mail server with the option
`-e "MAILHUB=<IP:PORT>"`
on `docker run`