### PR TITLE
Move runtime env vars into build time arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7.4.1708
 
 # ARG can be overwritten on build time using "docker build --build-arg name=value"
-ARG CMK_VERSION_ARG="1.4.0p15"
+ARG CMK_VERSION_ARG="1.4.0p19"
 ARG CMK_DOWNLOADNR_ARG="64"
 ARG CMK_SITE_ARG="mva"
 ARG MAILHUB="undefined"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM centos:7.4.1708
 
-ENV CMK_VERSION="1.4.0p15"
-ENV CMK_DOWNLOADNR="62"
-ENV CMK_SITE="mva"
+# ARG can be overwritten on build time using "docker build --build-arg name=value"
+ARG CMK_VERSION_ARG="1.4.0p15"
+ARG CMK_DOWNLOADNR_ARG="64"
+ARG CMK_SITE_ARG="mva"
+
+# After Build the ENV vars are initialized with the value of there build argument.
+ENV CMK_VERSION=${CMK_VERSION_ARG}
+ENV CMK_DOWNLOADNR=${CMK_DOWNLOADNR_ARG}
+ENV CMK_SITE=${CMK_SITE_ARG}
 ENV MAILHUB="undefined"
 
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7.4.1708
 
 # ARG can be overwritten on build time using "docker build --build-arg name=value"
 ARG CMK_VERSION_ARG="1.4.0p19"
-ARG CMK_DOWNLOADNR_ARG="64"
+ARG CMK_DOWNLOADNR_ARG="66"
 ARG CMK_SITE_ARG="mva"
 ARG MAILHUB="undefined"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,13 @@ FROM centos:7.4.1708
 ARG CMK_VERSION_ARG="1.4.0p15"
 ARG CMK_DOWNLOADNR_ARG="64"
 ARG CMK_SITE_ARG="mva"
+ARG MAILHUB="undefined"
 
 # After Build the ENV vars are initialized with the value of there build argument.
 ENV CMK_VERSION=${CMK_VERSION_ARG}
 ENV CMK_DOWNLOADNR=${CMK_DOWNLOADNR_ARG}
 ENV CMK_SITE=${CMK_SITE_ARG}
-ENV MAILHUB="undefined"
+ENV MAILHUB=${MAILHUB}
 
 RUN \
     yum -y install epel-release && \


### PR DESCRIPTION
The ENV vars are used while building the container, instead of proper arg vars.
If arg vars are used, they can be overwritten while building the container using "--build-arg" effectively allowing to change the command executed in the "RUN" part, as run is only executed at container build time and not at Instantiation time.